### PR TITLE
Size version select to menu bar height

### DIFF
--- a/docs/mdbook/js/version-dropdown.js
+++ b/docs/mdbook/js/version-dropdown.js
@@ -21,25 +21,35 @@
         // Create container
         const container = document.createElement('div');
         container.id = 'mdbook-version-container';
+        const menuBarHeight = Math.round(menuBar.getBoundingClientRect().height);
+        const selectHeight = Math.max(menuBarHeight - 10, 32);
         container.style.cssText = `
-            display: inline-block;
-            margin-left: 1rem;
-            vertical-align: middle;
+            display: flex;
+            align-items: center;
+            margin-right: auto;
+            margin-left: 0.75rem;
+            height: ${menuBarHeight}px;
         `;
 
         // Create select
         const select = document.createElement('select');
         select.id = 'mdbook-version-select';
         select.style.cssText = `
-            padding: 0.3rem 0.5rem;
-            font-size: 0.9rem;
+            padding: 0 0.75rem;
+            font-size: 0.95rem;
+            font-family: inherit;
             border-radius: 5px;
             border: 1px solid #ccc;
             background-color: #0b3954;
             color: white;
             font-weight: bold;
             cursor: pointer;
+            height: ${selectHeight}px;
+            min-width: 12rem;
+            box-sizing: border-box;
+            line-height: 1.2;
         `;
+        container.appendChild(select);
 
         // Populate options
         versions.forEach(v => {
@@ -74,7 +84,7 @@
         window.location.href = newUrl;
     });
 
-        menuBar.prepend(container)
+        menuBar.prepend(container);
 
     }
 
@@ -89,4 +99,3 @@
 
     observer.observe(document.body, { childList: true, subtree: true });
 })();
-


### PR DESCRIPTION
### Motivation
- Address the issue where the version select was only ~22.5px high while the menu bar was ~50px by sizing the dropdown to match the actual menu bar height so it's usable and visually centered.
- Prevent the selector from collapsing header layout and ensure a consistent minimum height across themes and varying menu bar sizes.

### Description
- Compute `menuBarHeight` from `menuBar.getBoundingClientRect().height` and derive `selectHeight` with `selectHeight = Math.max(menuBarHeight - 10, 32)`.
- Set `#mdbook-version-container` to `display: flex` with `align-items: center`, adjusted margins, and `height: ${menuBarHeight}px` so it participates in header layout.
- Style `#mdbook-version-select` to use the computed `height`, adjusted `padding`, `font-size`, `font-family`, `min-width`, `box-sizing`, and `line-height` for consistent sizing and typography.
- Move `container.appendChild(select)` before populating options so the select participates in layout while options are added, and keep options population and navigation logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698741e300508329887cbe671aa2841d)